### PR TITLE
[SampleFramework12] Fix potential upload ordering problem

### DIFF
--- a/SampleFramework12/v1.01/Graphics/DX12_Upload.cpp
+++ b/SampleFramework12/v1.01/Graphics/DX12_Upload.cpp
@@ -119,6 +119,10 @@ static void ClearFinishedUploads(uint64 flushCount)
             if(UploadBufferUsed == 0)
                 UploadBufferStart = 0;
         }
+        else
+        {
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
(disclaimer: I didn't test this project nor this 'fix', I just read some of the code, so take this with a grain of salt)

The submissions are allocated from ResourceUploadBegin, but their fence value are only populated from ResourceUploadEnd.
Hence, a submission A could potentially have a bigger fence value than a later allocated submission B.
I think it could create an issue here: submission A's fence could be not signaled while submission B's would be signaled, and this code would invalidate the ring buffer's implicit fifo contract (as it would try to remove submission B without first removing submission A).
 It would probably crash on `Assert_(submission.Offset == UploadBufferStart);`

To further explicit the fifo contract, one could also add at the beginning of the Signaled block:
`Assert_(idx == UploadSubmissionStart);`