### PR TITLE
Use initial resource state GENERIC_READ for buffers on upload heap

### DIFF
--- a/SampleFramework12/v1.01/Graphics/GraphicsTypes.cpp
+++ b/SampleFramework12/v1.01/Graphics/GraphicsTypes.cpp
@@ -262,6 +262,10 @@ void Buffer::Initialize(uint64 size, uint64 alignment, bool32 dynamic, bool32 cp
 
     const D3D12_HEAP_PROPERTIES* heapProps = cpuAccessible ? DX12::GetUploadHeapProps() : DX12::GetDefaultHeapProps();
 
+    D3D12_RESOURCE_STATES resourceState = D3D12_RESOURCE_STATE_COMMON;
+    if (cpuAccessible)
+      resourceState = D3D12_RESOURCE_STATE_GENERIC_READ;
+
     if(heap)
     {
         Heap = heap;
@@ -272,7 +276,7 @@ void Buffer::Initialize(uint64 size, uint64 alignment, bool32 dynamic, bool32 cp
     else
     {
         DXCall(DX12::Device->CreateCommittedResource(heapProps, D3D12_HEAP_FLAG_NONE, &resourceDesc,
-                                                        D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&Resource)));
+          resourceState, nullptr, IID_PPV_ARGS(&Resource)));
     }
 
     if(name)


### PR DESCRIPTION
Fixes the following error:
D3D12 ERROR: ID3D12Device::CreateCommittedResource: Certain resources are restricted to certain D3D12_RESOURCE_STATES states, and cannot be changed. Resources on D3D12_HEAP_TYPE_UPLOAD heaps requires D3D12_RESOURCE_STATE_GENERIC_READ.